### PR TITLE
Remove "Examples" link on the bottom

### DIFF
--- a/source/Footer.mint
+++ b/source/Footer.mint
@@ -55,11 +55,6 @@ component Footer {
             href="https://github.com/mint-lang/mint/releases"
             label="Releases / Changelog"
             target="_blank"/>
-
-          <Ui.Link
-            href="https://github.com/mint-lang/mint-examples"
-            label="Examples"
-            target="_blank"/>
         </div>
 
         <div::column>


### PR DESCRIPTION
I removed it because right now when you click it then leads to a 404 GitHub page and there is already a link to examples on the top of the page.