### PR TITLE
Fix typo

### DIFF
--- a/source/Pages/Install.mint
+++ b/source/Pages/Install.mint
@@ -181,7 +181,7 @@ component Install {
             "ing_homebrew.html"
           }>
 
-          <{ "install Cystal" }>
+          <{ "install Crystal" }>
 
         </a>
 


### PR DESCRIPTION
`Cystal` to `Crystal`