### PR TITLE
typo: use preferred capitalization

### DIFF
--- a/source/Components/Footer.mint
+++ b/source/Components/Footer.mint
@@ -50,7 +50,7 @@ component Footer {
             rel="noreferrer"
             target="_blank">
 
-            "Github Repository"
+            "GitHub Repository"
 
           </a>
 


### PR DESCRIPTION
I noticed the misuse of lowercase "hub".