### PR TITLE
Add tooltips to type indicators on API docs pages

### DIFF
--- a/source/Modules/ApiDocs.mint
+++ b/source/Modules/ApiDocs.mint
@@ -58,4 +58,22 @@ module ApiDocs {
       => "#{kind}"
     }
   }
+
+  fun kindToWord (kind : Number) {
+    case kind {
+      0 => ""
+      1 => "Component"
+      2 => "Provider"
+      3 => "Property"
+      4 => "Function"
+      5 => "Constant"
+      6 => "Module"
+      7 => "Signal"
+      8 => "Store"
+      9 => "State"
+      10 => "Type"
+      11 => "Computed Property"
+      => "#{kind}"
+    }
+  }
 }

--- a/source/Pages/ApiDocs.mint
+++ b/source/Pages/ApiDocs.mint
@@ -79,7 +79,7 @@ async component Pages.ApiDocs {
     let {char, color} =
       ApiDocs.kindToBadge(kind)
 
-    <span::badge(color) title={ApiDocs.kindToKeyword(kind)}>char</span>
+    <span::badge(color) title={ApiDocs.kindToWord(kind)}>char</span>
   }
 
   // Renders the component.

--- a/source/Pages/ApiDocs.mint
+++ b/source/Pages/ApiDocs.mint
@@ -70,6 +70,8 @@ async component Pages.ApiDocs {
 
     height: 16px;
     width: 16px;
+
+    cursor: help;
   }
 
   // Renders a badge based on the kind of the entity.
@@ -77,7 +79,7 @@ async component Pages.ApiDocs {
     let {char, color} =
       ApiDocs.kindToBadge(kind)
 
-    <span::badge(color)>char</span>
+    <span::badge(color) title={ApiDocs.kindToKeyword(kind)}>char</span>
   }
 
   // Renders the component.


### PR DESCRIPTION
<img width="241" height="235" alt="image" src="https://github.com/user-attachments/assets/8866239d-4929-4d65-850e-d32424de5a83" />

This is also helpful for sighted users but probably even more does it add to the accessibility of the site