### PR TITLE
Add GitHub release link to package version info

### DIFF
--- a/source/Modules/Packages.mint
+++ b/source/Modules/Packages.mint
@@ -19,7 +19,7 @@ module Packages {
                 [
                   {"Readme", TablerIcons.BOOK, package.readme},
                   {"Source", TablerIcons.BRAND_GITHUB, package.url},
-                  {package.version, TablerIcons.VERSIONS, ""}
+                  {package.version, TablerIcons.VERSIONS, "#{package.url}/releases/tag/#{package.version}"}
                 ]
             })
 


### PR DESCRIPTION
<img width="241" height="137" alt="image" src="https://github.com/user-attachments/assets/dae04f2b-feb0-4aa4-b941-bb9622b1d1e4" />

This will now lead to https://github.com/mint-lang/mint-color/releases/tag/0.10.0