### PR TITLE
Add mint-vscode to Tools page

### DIFF
--- a/source/Data/Tools.mint
+++ b/source/Data/Tools.mint
@@ -5,6 +5,11 @@ module Data {
         description: "A code generation utility that converts OpenAPI 3.0 specifications into idiomatic Mint language client code.",
         name: "mint-oapi-codegen",
         url: "https://github.com/saviorand/mint-oapi-codegen"
+      },
+      {
+        description: "Visual Studio Code extension providing syntax highlighting, formatting, code snippets, and commands for the Mint programming language.",
+        name: "mint-vscode",
+        url: "https://github.com/mint-lang/mint-vscode"
       }
     ]
 }


### PR DESCRIPTION
Add Visual Studio Code extension for Mint to the tools list, providing syntax highlighting, formatting, snippets, and commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)